### PR TITLE
chore: add composer validate & normalize CI check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -10,7 +10,7 @@
         {
             "name": "Composer validate & normalize",
             "job": {
-                "command": "composer validate --strict --no-check-publish && composer normalize --dry-run --diff",
+                "command": "composer validate --strict && composer normalize --dry-run --diff",
                 "php": "@lowest",
                 "dependencies": "locked"
             }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "silarhi/cfonb-reader",
+    "description": "CFONB statement file reader",
     "license": "proprietary",
     "type": "project",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c58c5b87693d5a77956d5db84f51d0b",
+    "content-hash": "60286be4df7a16a79dd0e8e009727a7e",
     "packages": [
         {
             "name": "monolog/monolog",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     },
     "lint-staged": {
         "*.{js,css,scss,md}": "prettier --write",
-        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+        "composer.json": "composer normalize"
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.1",


### PR DESCRIPTION
Adds composer.json quality enforcement, consistent with `silarhi/picasso-bundle`:

- `ergebnis/composer-normalize` dev dependency + its `allow-plugins` entry
- lint-staged hook running `composer normalize` on `composer.json`
- laminas-ci `additional_checks` step running `composer validate --strict && composer normalize --dry-run --diff`
- `composer.lock` content-hash refreshed
